### PR TITLE
Prevent empty embeds from being sent

### DIFF
--- a/bukkit/src/main/java/com/alessiodp/oreannouncer/bukkit/addons/external/DiscordSRVHandler.java
+++ b/bukkit/src/main/java/com/alessiodp/oreannouncer/bukkit/addons/external/DiscordSRVHandler.java
@@ -162,5 +162,12 @@ public class DiscordSRVHandler {
 		private final String title;
 		private final String description;
 		private final String footer;
+
+		public boolean hasContent() {
+			return !authorName.isEmpty() ||
+					!title.isEmpty() ||
+					!description.isEmpty() ||
+					!footer.isEmpty();
+		}
 	}
 }

--- a/bukkit/src/main/java/com/alessiodp/oreannouncer/bukkit/addons/external/hooks/DiscordSRVHook.java
+++ b/bukkit/src/main/java/com/alessiodp/oreannouncer/bukkit/addons/external/hooks/DiscordSRVHook.java
@@ -46,19 +46,21 @@ public class DiscordSRVHook {
 	}
 	
 	public void sendMessageEmbed(OAPlayerImpl player, Function<String, String> parser, String channel, DiscordSRVHandler.DiscordSRVAlertEmbed embed) {
-		TextChannel textChannel = api.getDestinationTextChannelForGameChannelName(channel);
-		if (textChannel != null) {
-			MessageFormat mf = new MessageFormat();
-			CommonUtils.ifNonNullDo(parseHexColor(embed.getColor()), mf::setColor);
-			CommonUtils.ifNonEmptyDo(embed.getAuthorName(), txt -> mf.setAuthorName(parser.apply(txt)));
-			CommonUtils.ifNonEmptyDo(embed.getTitle(), txt -> mf.setTitle(parser.apply(txt)));
-			CommonUtils.ifNonEmptyDo(embed.getDescription(), txt -> mf.setDescription(parser.apply(txt)));
-			CommonUtils.ifNonEmptyDo(embed.getFooter(), txt -> mf.setFooterText(parser.apply(txt)));
-			
-			if (BukkitConfigMain.ALERTS_DISCORDSRV_EMBED_AVATARS && player != null)
-				mf.setAuthorImageUrl(api.getEmbedAvatarUrl(player.getName(), player.getPlayerUUID()));
-			
-			DiscordUtil.queueMessage(textChannel, api.translateMessage(mf, (content, needEscape) -> content));
+		if (embed != null && embed.hasContent()) {
+			TextChannel textChannel = api.getDestinationTextChannelForGameChannelName(channel);
+			if (textChannel != null) {
+				MessageFormat mf = new MessageFormat();
+				CommonUtils.ifNonNullDo(parseHexColor(embed.getColor()), mf::setColor);
+				CommonUtils.ifNonEmptyDo(embed.getAuthorName(), txt -> mf.setAuthorName(parser.apply(txt)));
+				CommonUtils.ifNonEmptyDo(embed.getTitle(), txt -> mf.setTitle(parser.apply(txt)));
+				CommonUtils.ifNonEmptyDo(embed.getDescription(), txt -> mf.setDescription(parser.apply(txt)));
+				CommonUtils.ifNonEmptyDo(embed.getFooter(), txt -> mf.setFooterText(parser.apply(txt)));
+
+				if (BukkitConfigMain.ALERTS_DISCORDSRV_EMBED_AVATARS && player != null)
+					mf.setAuthorImageUrl(api.getEmbedAvatarUrl(player.getName(), player.getPlayerUUID()));
+
+				DiscordUtil.queueMessage(textChannel, api.translateMessage(mf, (content, needEscape) -> content));
+			}
 		}
 	}
 	


### PR DESCRIPTION
This fixes an issue where empty embeds may be sent to Discord via DiscordSRV with the default empty configuration.